### PR TITLE
Fix echo-route 503 errors from request termination

### DIFF
--- a/kong.yaml
+++ b/kong.yaml
@@ -6,7 +6,6 @@ plugins:
   - name: request-termination
     config:
       status_code: 503
-      message: '"Service is now unavailable"'
 services:
   - name: echo-service
     path: /anything

--- a/kong.yaml
+++ b/kong.yaml
@@ -4,7 +4,6 @@ plugins:
     config:
       per_consumer: true
   - name: request-termination
-    config:
       status_code: 503
 services:
   - name: echo-service


### PR DESCRIPTION
Fix 503 Service Unavailable errors on echo-route by removing global request-termination plugin