### PR TITLE
Fix Kong service 503 errors - Switch to httpbingo.org

### DIFF
--- a/kong.yaml
+++ b/kong.yaml
@@ -6,7 +6,7 @@ plugins:
 services:
   - name: echo-service
     path: /anything
-    host: httpbin.org
+    host: httpbingo.org
     port: 443
     protocol: https
     routes:


### PR DESCRIPTION
Fix 503 errors by switching from httpbin.org to httpbingo.org