### PR TITLE
Fix prometheus plugin causing 503 errors for anonymous requests

### DIFF
--- a/kong.yaml
+++ b/kong.yaml
@@ -2,7 +2,6 @@ _format_version: "3.0"
 plugins:
   - name: prometheus
     config:
-      per_consumer: true
 services:
   - name: echo-service
     path: /anything


### PR DESCRIPTION
Fix prometheus plugin configuration causing 503 errors

The prometheus plugin was configured with 'per_consumer: true' which requires all requests to have a consumer ID. This caused anonymous requests to receive 503 errors. Removing this configuration allows anonymous requests to be processed correctly while still collecting prometheus metrics.