### PR TITLE
Fix Remove failing request-termination plugin causing 100 percent error rate

### DIFF
--- a/kong.yaml
+++ b/kong.yaml
@@ -3,7 +3,6 @@ plugins:
   - name: prometheus
     config:
       per_consumer: true
-  - name: request-termination
     config:
       status_code: 503
       message: '"Service is now unavailable"'

--- a/kong.yaml
+++ b/kong.yaml
@@ -3,7 +3,6 @@ plugins:
   - name: prometheus
     config:
       per_consumer: true
-    config:
       status_code: 503
       message: '"Service is now unavailable"'
 services:

--- a/kong.yaml
+++ b/kong.yaml
@@ -3,7 +3,6 @@ plugins:
   - name: prometheus
     config:
       per_consumer: true
-      status_code: 503
       message: '"Service is now unavailable"'
 services:
   - name: echo-service

--- a/kong.yaml
+++ b/kong.yaml
@@ -3,7 +3,6 @@ plugins:
   - name: prometheus
     config:
       per_consumer: true
-      message: '"Service is now unavailable"'
 services:
   - name: echo-service
     path: /anything


### PR DESCRIPTION
Remove request-termination plugin causing 100% error rate

- Found route f999167d-c44a-4bca-b430-47dc5ad19bd6 (echo-route) with 100% failure rate
- All requests returning 503 status due to global request-termination plugin
- Removing the plugin to restore normal service functionality
- Control plane: ai-auto-rollback (4f480887-6d74-481b-9037-d3abad7dba85)